### PR TITLE
Fix #11

### DIFF
--- a/leaflet-measure-path.js
+++ b/leaflet-measure-path.js
@@ -162,14 +162,12 @@
         if (!hookAfter) {
             return function() {
                 method.apply(this, arguments);
-                fn.apply(this, arguments);
-                return this;
+                return fn.apply(this, arguments);
             }
         } else {
             return function() {
                 fn.apply(this, arguments);
-                method.apply(this, arguments);
-                return this;
+                return method.apply(this, arguments);
             }
         }
     };

--- a/leaflet-measure-path.js
+++ b/leaflet-measure-path.js
@@ -163,11 +163,13 @@
             return function() {
                 method.apply(this, arguments);
                 fn.apply(this, arguments);
+                return this;
             }
         } else {
             return function() {
                 fn.apply(this, arguments);
                 method.apply(this, arguments);
+                return this;
             }
         }
     };


### PR DESCRIPTION
Return the original object in the override function so chained methods work again.