### PR TITLE
fix: syntax error due to const in ie

### DIFF
--- a/leaflet-measure-path.js
+++ b/leaflet-measure-path.js
@@ -157,7 +157,7 @@
      * Implements the showOnHover functionality if called for.
      */
     var addInitHook = function() {
-        const showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
+        var showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
         if (this.options.showMeasurements && !showOnHover) {
             this.showMeasurements();
         }
@@ -227,7 +227,7 @@
         },
 
         onAdd: override(L.Polyline.prototype.onAdd, function() {
-            const showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
+            var showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
             if (this.options.showMeasurements && !showOnHover) {
                 this.showMeasurements(this.options.measurementOptions);
             }
@@ -356,7 +356,7 @@
         },
 
         onAdd: override(L.Circle.prototype.onAdd, function() {
-            const showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
+            var showOnHover = this.options.measurementOptions && this.options.measurementOptions.showOnHover;
             if (this.options.showMeasurements && !showOnHover) {
                 this.showMeasurements(this.options.measurementOptions);
             }


### PR DESCRIPTION
I try use that plugin with webpack, and have chunk error:
![photo_2019-02-19_20-30-48](https://user-images.githubusercontent.com/16123366/53034892-471eb400-3485-11e9-8fd7-f70b2e3dd9e9.jpg)

Because by default webpack and any bundlers dont transpile modules from node_modules dir with babel. I changed all const to var in source code, and leaflet-measure-path no longer breaks webpack chunks in ie.