### PR TITLE
Updates polyline measurements on edit

### DIFF
--- a/leaflet-measure-path.js
+++ b/leaflet-measure-path.js
@@ -266,6 +266,10 @@
             return originalReturnValue;
         }),
 
+        _updatePath: override(L.Polyline.prototype._updatePath, function() {
+            this.updateMeasurements();
+        }),
+
         formatDistance: formatDistance,
         formatArea: formatArea,
 

--- a/leaflet-measure-path.js
+++ b/leaflet-measure-path.js
@@ -431,4 +431,11 @@
     L.Circle.addInitHook(function() {
         addInitHook.call(this);
     });
+
+    L.Polygon.include({
+        _updatePath: override(L.Polygon.prototype._updatePath, function() {
+            this.updateMeasurements();
+        }),
+    })
+
 })();


### PR DESCRIPTION
Currently if you edit a polyline, the measurements don't update until you stop editing. ~~The polygon edges update during editing, so this PR makes the plugin more consistent since the polyline behaves more like polygons.~~

You can reproduce the current behaviour by:

1. going to the demo page https://prominentedge.com/leaflet-measure-path/
2. Making the polyline editable by entering to console `map._layers[39].enableEdit()`
3. Dragging the polyline corners doesn't update the polyline measurements

EDIT: Polygon doesn't update actually properly when editing, but rectangle does. I'll apply the fix for polygon also.
EDIT2: Polygon fixed now also